### PR TITLE
Perform a Player Registration check upon creating an RDL game

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -16,6 +16,11 @@ PREFIX = os.getenv('COMMAND_PREFIX')
 if (PREFIX is None):
     PREFIX = "!"
 
+# The Base URL that the bot will use to lookup Player Registrations as soon as an RDL game starts. If not provided,
+# the bot will not check for player registrations.
+# Example: https://rootleague.pliskin.dev/api/registration
+RDL_PLAYER_REGISTRATION_BASE_URL = os.getenv('RDL_PLAYER_REGISTRATION_BASE_URL', None)
+
 intents = discord.Intents.all()
 intents.typing = False
     

--- a/config/games.ini
+++ b/config/games.ini
@@ -20,7 +20,8 @@ GamesRoles = <@&746019278892957787>, <@&536618324965195776>, <@&8418094269392486
 GamesIcons = https://i.imgur.com/mJg2ySj.png, https://i.imgur.com/yo0DBV4.jpg, https://i.imgur.com/mJg2ySj.png, https://i.imgur.com/mJg2ySj.png, https://i.imgur.com/wTD7pts.jpeg, https://i.imgur.com/7NGPV2v.png, https://i.imgur.com/eI0h8dQ.jpeg, https://i.imgur.com/JzqoYiN.png, 
 GamesForums = , , 1068560342671700088, 1068560342671700088, , , , , 
 GamesTags = , , Game, Game, , , , , 
-GamesMessages = , , And remember to check the rules here: https://rootleague.pliskin.dev/pages/about/rules/, And remember to check the rules here: https://rootleague.pliskin.dev/pages/about/rules/, , , , , 
+GamesMessages = , , And remember to check the rules here: https://rootleague.pliskin.dev/pages/about/rules/, And remember to check the rules here: https://rootleague.pliskin.dev/pages/about/rules/, , , , ,
+GamesThreadCreateHandlers= , , after_rdl_thread_created, after_rdl_thread_created, , , , ,
 
 [BF]
 ID = 1093600731644305590

--- a/plugins/matchmaking.py
+++ b/plugins/matchmaking.py
@@ -1,8 +1,11 @@
+
+import aiohttp
 import discord
 from discord.ext import commands, tasks
 import configparser
 import re
 
+from bot import RDL_PLAYER_REGISTRATION_BASE_URL
 from utils import common
 
 LFG_COMMAND = "lfg"
@@ -16,6 +19,7 @@ CONFIG_GAMES_FORUMS = "GamesForums"
 CONFIG_GAMES_TAGS = "GamesTags"
 CONFIG_GAMES_VISIBILITY = "GamesVisibility"
 CONFIG_GAMES_MESSAGES = "GamesMessages"
+CONFIG_GAMES_THREAD_CREATE_HANDLERS = "GamesThreadCreateHandlers"
 
 EMOJI_JOIN = "👍"
 EMOJI_NOTIFY = "🔔"
@@ -342,13 +346,14 @@ class matchmaking(commands.Cog):
         #          c) Create thread under this message otherwise
     
         gamesRoles, gamesForums, gamesTags, \
-        gamesVisibility, gamesMessages = \
+        gamesVisibility, gamesMessages, gamesThreadCreateHandlers = \
         self.get_configured_games(message.guild.id, \
                                   CONFIG_GAMES_ROLES, \
                                   CONFIG_GAMES_FORUMS, \
                                   CONFIG_GAMES_TAGS, \
                                   CONFIG_GAMES_VISIBILITY, \
-                                  CONFIG_GAMES_MESSAGES)
+                                  CONFIG_GAMES_MESSAGES, \
+                                  CONFIG_GAMES_THREAD_CREATE_HANDLERS)
         nbGames = len(gamesRoles)
         index = -1
         if (nbGames and len(target) and target in gamesRoles):
@@ -415,7 +420,13 @@ class matchmaking(commands.Cog):
             keywords['message'] = parent_message
         if (not(thread_visibility)):
             keywords['type'] = discord.ChannelType.private_thread
-        
+
+        thread_create_handler = None
+        if (index >= 0 and nbGames == len(gamesThreadCreateHandlers)):
+            handler_name = gamesThreadCreateHandlers[index]
+            if handler_name:
+                thread_create_handler = getattr(self, handler_name, None)
+
         try:
             thread = await thread_channel.create_thread(**keywords)
             if (thread_in_forum):
@@ -423,11 +434,34 @@ class matchmaking(commands.Cog):
             if (thread is not None):
                 if (not(thread_in_forum)):
                     await thread.send(content=thread_message, embed=thread_embed)
+                    if thread_create_handler:
+                        await thread_create_handler(thread)
                 embed.url = thread.jump_url
                 await message.edit(embed=embed)
         except Exception as e:
             print(e)
-    
+
+    async def after_rdl_thread_created(self, thread):
+        if not RDL_PLAYER_REGISTRATION_BASE_URL:
+            return
+
+        thread_members = await thread.fetch_members()
+
+        async with aiohttp.ClientSession() as session:
+            for thread_member in thread_members:
+                if thread_member.id == self.bot.user.id:
+                    # Skip the bot's user itself
+                    continue
+                user = await self.bot.fetch_user(thread_member.id)
+                async with session.get(F"{RDL_PLAYER_REGISTRATION_BASE_URL}/" + user.name + "/") as response:
+                    if response.status != 200:
+                        await thread.send(
+                            content=F"Welcome to the Root Digital League, {user.mention}! I couldn't find your "
+                                    "registration on the League's website. Please register on "
+                                    "https://rootleague.pliskin.dev/ and double-check that your profile has the "
+                                    "correct Discord username.")
+
+
 async def setup(bot):
     config = configparser.ConfigParser()
     config.read('config/games.ini')


### PR DESCRIPTION
The ultimate goal of the changes in this pull request is for the bot to automatically check whether everyone in an RDL game has registered on the League website.

To do this, I've added a way to call a named method as soon as a specific game's thread is created. The name of the handler to call is given in the `games.ini` file. In this case, we add a handler for RDL games which instructs the Bot to lookup a Player's Registration, using their Discord username, on the RDL website, and using the new API that was added with https://github.com/PliskinGH/RootLeague/pull/8.

If the bot does not find a player with the given Discord username, it will post a message similar to the one shown below:

<img width="2238" height="442" alt="image" src="https://github.com/user-attachments/assets/5fbe8719-e8bf-4894-a493-f945785b10fc" />

**Important**
When running the bot, the `RDL_PLAYER_REGISTRATION_BASE_URL` environment variable must now be specified to point to the RDL Player registration API. If you wish to disable this new functionality, you may simply run the bot without the `RDL_PLAYER_REGISTRATION_BASE_URL` variable.